### PR TITLE
Fix StreamServerInterceptor doc example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -62,8 +62,8 @@ needed. For example:
 
 	func FakeAuthStreamingInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	   newStream := grpc_middleware.WrapServerStream(stream)
-	   newStream.WrappedContext = context.WithValue(ctx, "user_id", "john@example.com")
-	   return handler(srv, stream)
+	   newStream.WrappedContext = context.WithValue(stream.Context(), "user_id", "john@example.com")
+	   return handler(srv, newStream)
 	}
 */
 package grpc_middleware


### PR DESCRIPTION
Fix the example showing how to store a value into a stream context:
- get the stream context out of the stream object.
- pass the newly created wrapped stream to the handler.